### PR TITLE
fix default config: use supported rpc wallet call

### DIFF
--- a/config.json
+++ b/config.json
@@ -130,7 +130,7 @@
         },
         "wallet": {
             "checkInterval": 60,
-            "rpcMethod": "get_address_count"
+            "rpcMethod": "getbalance"
         }
     },
 


### PR DESCRIPTION
default config doesn't work with "rpcMethod": "get_address_count"