### PR TITLE
Fixed excessive xmlHttpRequests on home.html

### DIFF
--- a/website/config.js
+++ b/website/config.js
@@ -48,7 +48,8 @@ var networkStat = {
         ["pool2.karbowanec.com", "http://pool2.karbowanec.com:8117"],
         ["krb.sberex.com", "http://krb.sberex.com:7006"],
         ["krb.crypto-coins.club", "http://krb.crypto-coins.club:8118"],
-        ["krb.cryptonotepool.com", "http://5.189.135.137:8618"]
+        ["krb.cryptonotepool.com", "http://5.189.135.137:8618"],
+        ["krbpool.ml", "http://krbpool.ml:8117"]
     ],
     "qcn": [
         ["qcn.mypool.online", "http://qcn.mypool.online:23084"]

--- a/website/index.html
+++ b/website/index.html
@@ -357,7 +357,7 @@
             <a class="navbar-brand active" href="#"><span id="coinName"></span> Mining Pool</a>
         </div>
         <div class="collapse navbar-collapse">
-            <ul class="nav navbar-nav">
+            <ul class="nav navbar-nav" data-toggle="collapse" data-target=".navbar-collapse">
 
                 <li style="display:none;" class="active"><a class="hot_link" data-page="home.html" href="#">
                     <i class="fa fa-home"></i> Home

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -524,18 +524,16 @@
 
                     renderPayments(data.payments);
 
-                    $('.yourStats').show(function(){
-                        xhrRenderUserCharts = $.ajax({
-                            url: api + '/stats_address?address=' + address + '&longpoll=false',            
-                            cache: false,
-                            dataType: 'json',            
-                            success: function(data) {
-                                createUserCharts(data);                                
-                            }
-                        });
-                    });
-                    
-                    
+                    $('.yourStats').show();
+					
+					xhrRenderUserCharts = $.ajax({
+						url: api + '/stats_address?address=' + address + '&longpoll=false',            
+						cache: false,
+						dataType: 'json',            
+						success: function(data) {
+							createUserCharts(data);                                
+						}
+					});
 
                     docCookies.setItem('mining_address', address, Infinity);
 

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -525,15 +525,15 @@
                     renderPayments(data.payments);
 
                     $('.yourStats').show();
-					
-					xhrRenderUserCharts = $.ajax({
-						url: api + '/stats_address?address=' + address + '&longpoll=false',            
-						cache: false,
-						dataType: 'json',            
-						success: function(data) {
-							createUserCharts(data);                                
-						}
-					});
+
+                    xhrRenderUserCharts = $.ajax({
+                        url: api + '/stats_address?address=' + address + '&longpoll=false',            
+                        cache: false,
+                        dataType: 'json',            
+                        success: function(data) {
+                            createUserCharts(data);                                
+                        }
+                    });
 
                     docCookies.setItem('mining_address', address, Infinity);
 


### PR DESCRIPTION
To reproduce - open chrome - F12 (dev panel) - Network - on home page, input valid address to lookup, and wait several seconds.
There are 9 similar requests spawning every n seconds with `&longpoll=false`

That is because `$('.yourStats').show(function() ...)` calls the `function()` for every element with class `yourStats`.