### PR TITLE
Better readable network difficulty

### DIFF
--- a/website/config.js
+++ b/website/config.js
@@ -49,7 +49,8 @@ var networkStat = {
         ["krb.sberex.com", "http://krb.sberex.com:7006"],
         ["krb.crypto-coins.club", "http://krb.crypto-coins.club:8118"],
         ["krb.cryptonotepool.com", "http://5.189.135.137:8618"],
-        ["krbpool.ml", "http://krbpool.ml:8117"]
+        ["krbpool.ml", "http://krbpool.ml:8117"],
+        ["mine4all.pp.ua", "http://mine4all.pp.ua:8877"]
     ],
     "qcn": [
         ["qcn.mypool.online", "http://qcn.mypool.online:23084"]

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -317,7 +317,7 @@
             $('#networkLastBlockFound').timeago('update', new Date(lastStats.network.timestamp * 1000).toISOString());
 
             updateText('networkHashrate', getReadableHashRateString(lastStats.network.difficulty / lastStats.config.coinDifficultyTarget) + '/sec');
-            updateText('networkDifficulty', lastStats.network.difficulty.toString());
+            updateText('networkDifficulty', getReadableHashRateString(lastStats.network.difficulty);
             updateText('blockchainHeight', lastStats.network.height.toString());
             updateText('networkLastReward', getReadableCoins(lastStats.network.reward, 4));
             updateText('lastHash', lastStats.network.hash.substr(0, 13) + '...').setAttribute('href', getBlockchainUrl(lastStats.network.hash));


### PR DESCRIPTION
When difficulty is 1598298868 (for example) it's not readable. 1.49 GH is much better to read.